### PR TITLE
mongodb fuer news crawler persistence

### DIFF
--- a/Dockerfile_crawler
+++ b/Dockerfile_crawler
@@ -1,16 +1,33 @@
 # Use an official Python runtime as a parent image
 FROM python:3.6-slim
 
-# Set the working directory to /app
-WORKDIR /app
+# Define mountable directories.
+VOLUME ["/data/db"]
+
+# Define working directory.
+WORKDIR /data
 
 # Copy the current directory contents into the container at /app
-ADD . /app
+ADD . /data
+
+# Install MongoDB. debian sysvinit
+RUN \
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 && \
+  echo 'deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen' > /etc/apt/sources.list.d/mongodb.list && \
+  apt-get update && \
+  apt-get install -y mongodb-org && \
+  rm -rf /var/lib/apt/lists/*
+
+# run mongo daemon
+RUN mongod &
+
+# Expose ports.
+#   - 27017: process
+#   - 28017: http
+EXPOSE 27017
+EXPOSE 28017
 
 # Install any needed packages specified in requirements.txt
 RUN pip install -r requirements.txt
-
-# Make port available to the world outside this container
-#EXPOSE 5000
 
 CMD ["python", "news_crawler/newsreader.py"]

--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ Visit `http://localhost` after you have built and ran the image.
 
 ```
 docker build -f Dockerfile_crawler -t crawler .
-docker run crawler
+docker run -p 0.0.0.0:27017:27017 crawler
 ```

--- a/docker_cleanup.sh
+++ b/docker_cleanup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# remove exited containers:
+docker ps --filter status=dead --filter status=exited -aq | xargs -r docker rm -v
+
+# remove unused images:
+docker images --no-trunc | grep '<none>' | awk '{ print $3 }' | xargs -r docker rmi
+
+# remove unused volumes:
+find '/var/lib/docker/volumes/' -mindepth 1 -maxdepth 1 -type d | grep -vFf <(
+  docker ps -aq | xargs docker inspect | jq -r '.[] | .Mounts | .[] | .Name | select(.)'
+) | xargs -r rm -fr

--- a/news_crawler/newsreader.py
+++ b/news_crawler/newsreader.py
@@ -82,7 +82,7 @@ class NewsReader(object):
             for url in urls:
                 try:
                     title, text = NewsReader.fetch_url(url)
-                    articles.append((title, text))
+                    articles.append({'title': title, 'text': text})
                 except RuntimeError:
                     print('Could not get text from %s' % url)
                     pass
@@ -92,19 +92,13 @@ class NewsReader(object):
 
 def fetch_news():
     reader = NewsReader(sources=['spiegel'])
-    news = reader.get_news()
-    # todo: dump these to a persistence (i.e. mongo)
-    # and expose to outside of container
-    # for item in news:
-    #     print(item)
 
     persistence = MongoClient()
+
     db = persistence['test-database']
-    col = db['test']
-    insert_id = col.insert_one({'name': 'test'}).inserted_id
-    print("inserted doc with id", insert_id)
-    for elem in col.find():
-        print(elem)
+    col = db['articles']
+    col.delete_many({})
+    col.insert_many(reader.get_news())
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests==2.2.1
 bs4==0.0.1
 readability-lxml==0.6.2
 APScheduler==3.4.0
+pymongo==3.5.1


### PR DESCRIPTION
hi felix, kurzes update:

* mongodb wird mit dem crawler `Dockerfile` installiert und mit dem `newsreader.py` im hintergrund gestartet. hatte es mit `RUN` im eigentlichen `Dockerfile` nicht hinbekommen, es zu starten.
* `newsreader.py` verbindet sich mit mongodb und schreibt einen test datensatz. spaeter sollen dann alle artikel mit titel und text gespeichert werden.
* expose vom mongodb server port um die daten fuer andere container zugaenglich zu machen.
