### PR TITLE
manifesto model http facade

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '3'
 services:
+  manifesto_model:
+    build: manifesto_model
+    ports:
+     - "0.0.0.0:5000:5000"
   news_crawler:
     build: news_crawler
     ports:

--- a/services/manifesto_model/Dockerfile
+++ b/services/manifesto_model/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install -r requirements.txt
 EXPOSE 5000
 
 # Run app.py when the container launches
-CMD ["python", "manifesto-model.py"]
+CMD ["python", "main.py"]

--- a/services/manifesto_model/main.py
+++ b/services/manifesto_model/main.py
@@ -12,7 +12,7 @@ app.secret_key = 'development'
 
 @app.route('/user_labels', methods=['POST'])
 def user_labels():
-    # todo: forward to model http facade and receive bias estimation: manifesto_model:5000
+    # todo: bias estimation of this request and return estimate in response
     labels = json.loads(request.data.decode('utf-8'))
     print(labels)
     for entry in labels['data']:
@@ -22,7 +22,7 @@ def user_labels():
 
 @app.route('/get_samples')
 def get_samples():
-    # todo: call model http facade here
+    # todo: actually use model to return samples
     response = {
         'samples': [
             {'text': 'abc'},
@@ -32,10 +32,5 @@ def get_samples():
     return json.dumps(response)
 
 
-@app.route('/')
-def index():
-    return render_template('index.html')
-
-
 if __name__ == '__main__':
-    app.run(host="0.0.0.0", port=8080)
+    app.run(host="0.0.0.0", port=5000)

--- a/services/user_interface/templates/index.html
+++ b/services/user_interface/templates/index.html
@@ -80,9 +80,10 @@
                 'data': data
             };
             var request = makeHttpObject();
-            request.open("POST", "/user_labels", false);
+            var json = JSON.stringify(data);
+            request.open("POST", "/user_labels");
             request.setRequestHeader("Content-type", "application/json");
-            request.send(JSON.stringify(data));
+            request.send(json);
         }
 
     </script>


### PR DESCRIPTION
hey felix, ich habe eine rudimentaere http facade zu dem manifesto modell hinzugefuegt (der ganze estimation teil fehlt natuerlich noch).

die UI hat im wesentlichen zwei funktionen, einmal text samples vom modell abholen und diese dann, zumindest fuer jetzt, in links, neutral oder rechts einteilen. die kommunikation ist in zwei requests aufgeteilt:

* `GET /get_samples`, das modell liefert textsamples und erlaubt es in der UI dem nutzer die jeweiligen samples zu labeln. angedachtes format:
```
    response = {
        'samples': [
            {'text': 'abc'},
            {'text': 'abcd'}
        ]
    }
```
* `POST /user_labels`, im body stehen die jeweiligen texte mit den nutzer-annotationen. momentaner request body:
```
{
  "data": [
    {
      "text": "abc",
      "label": "neutral"
    },
    {
      "text": "abcd",
      "label": "left"
    }
  ]
}
```
als antwort auf den request wuerde die UI dann die jeweilige klassifikation des nutzers erwarten.

was meinst du?