### PR TITLE
Completed labelling pipeline

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=0 # unbuffered I/O with print etc. to always print to the console
       - HTTP_PORT=5000
+      - PERSISTENCE_HTTP_PORT=8888
     volumes:
       # mount development files to app
       - ./manifesto_model:/app

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=0 # unbuffered I/O with print etc. to always print to the console
       - HTTP_PORT=8888
+      - MANIFESTO_MODEL_HTTP_PORT=5000
       - DB_PATH=/db/active-manifesto.db
     volumes:
       # mount host database inside container

--- a/services/manifesto_model/api.py
+++ b/services/manifesto_model/api.py
@@ -44,7 +44,7 @@ def train():
     request_data = json.loads(request.get_data(as_text=True))['data']
     texts = list(map(lambda entry: entry['text'], request_data))
     labels = list(map(lambda entry: entry['label'], request_data))
-
+    print('training on', len(texts), 'samples')
     classifier.train(texts, labels)
 
     return jsonify({}), 201
@@ -82,7 +82,7 @@ def estimate_uncertainty():
 
     text_ids_priotized = np.array(text_ids)[np.array(prios_texts)]
     response_data = [{"text_id": int(tid)} for tid in text_ids_priotized]
-    print('priotized text ids', response_data)
+    # print('priotized text ids', response_data)
     return jsonify({"data": response_data})
 
 

--- a/services/manifesto_model/api.py
+++ b/services/manifesto_model/api.py
@@ -9,7 +9,7 @@ import json
 
 app = Flask(__name__)
 
-DEBUG = os.environ.get('DEBUG') != None
+DEBUG = True  # os.environ.get('DEBUG') != None
 VERSION = 0.1
 
 
@@ -22,7 +22,6 @@ def retrain():
     return Classifier(train=True)
 
 
-### API
 @app.route("/predict", methods=['POST'])
 def predict():
     text = request.form['text']
@@ -52,7 +51,7 @@ def train():
 
 
 @app.route("/estimate_uncertainty", methods=['POST'])
-def get_samples():
+def estimate_uncertainty():
     """
     estimates text uncertainties.
 
@@ -74,18 +73,20 @@ def get_samples():
     }
     """
     request_data = json.loads(request.get_data(as_text=True))['data']
+    # print('estimate_uncertainty', request_data)
     texts = list(map(lambda entry: entry['text'], request_data))
     text_ids = list(map(lambda entry: entry['text_id'], request_data))
 
     prios_texts = classifier.prioritize(texts)
+    # print('prios texts', prios_texts)
 
     text_ids_priotized = np.array(text_ids)[np.array(prios_texts)]
     response_data = [{"text_id": int(tid)} for tid in text_ids_priotized]
+    print('priotized text ids', response_data)
     return jsonify({"data": response_data})
 
 
 if __name__ == "__main__":
-    # port = int(os.environ.get('HTTP_PORT'))
     port = int(os.environ.get('HTTP_PORT'))
     classifier = Classifier(train=False)
     app.run(host='0.0.0.0', port=port, debug=DEBUG)

--- a/services/manifesto_model/api.py
+++ b/services/manifesto_model/api.py
@@ -24,7 +24,7 @@ def retrain():
     print('retrain called')
 
     url = 'http://persistence:{}/training_texts'.format(PERSISTENCE_HTTP_PORT)
-    print('sending data to manifesto model for training...')
+    print('requesting training data from persistence...')
     r = requests.get(url=url)
     print(r.status_code)
 
@@ -70,16 +70,13 @@ def estimate_uncertainty():
     }
     """
     request_data = json.loads(request.get_data(as_text=True))['data']
-    # print('estimate_uncertainty', request_data)
     texts = list(map(lambda entry: entry['text'], request_data))
     text_ids = list(map(lambda entry: entry['text_id'], request_data))
 
     prios_texts = classifier.prioritize(texts)
-    # print('prios texts', prios_texts)
 
     text_ids_priotized = np.array(text_ids)[np.array(prios_texts)]
     response_data = [{"text_id": int(tid)} for tid in text_ids_priotized]
-    # print('priotized text ids', response_data)
     return jsonify({"data": response_data})
 
 

--- a/services/manifesto_model/classifier.py
+++ b/services/manifesto_model/classifier.py
@@ -27,6 +27,10 @@ class Classifier:
 
         """
         self.clf = None
+        try:
+            self.clf = joblib.load('classifier.pickle')
+        except:
+            pass
 
     @staticmethod
     def smooth_probas(label_probas, eps=1e-9):

--- a/services/manifesto_model/requirements.txt
+++ b/services/manifesto_model/requirements.txt
@@ -5,3 +5,5 @@ bokeh==0.11.1
 seaborn==0.7.1
 sklearn
 Flask==0.10.1
+apscheduler==3.4.0
+requests==2.4.2

--- a/services/persistence/main.py
+++ b/services/persistence/main.py
@@ -34,7 +34,6 @@ def training_texts():
         ]
     }
     """
-    # todo: use this endpoint from manifesto model
     texts = get_texts_with_majority_voted_labels(1000000)
     texts = list(map(lambda entry: {'text': entry['statement'], 'label': entry['label']}, texts))
     return jsonify({'data': texts}), 200
@@ -60,19 +59,6 @@ def texts_and_labels():
 
     insert_into(DB_FILENAME, text_ids, labels, 'user')
     n_inserts = len(texts_with_labels)
-
-    # fixme: queue up examples and don't train on every user submission, or contact persistence with manifesto model with scheduler
-    training_data = {
-        'data': list(map(lambda entry: {'text': entry['statement'], 'label': entry['label']}, get_texts_with_majority_voted_labels(1000000)))
-    }
-    url = 'http://manifesto_model:{}/train'.format(MANIFESTO_MODEL_HTTP_PORT)
-    print('sending data to manifesto model for training...')
-    r = requests.post(
-        url=url,
-        json=training_data
-    )
-    print(r.status_code)
-    print(r.json())
 
     return jsonify({'n_inserted': n_inserts}), 201
 

--- a/services/persistence/main.py
+++ b/services/persistence/main.py
@@ -91,7 +91,6 @@ def prioritized_texts():
     )
     priotized_text_ids = list(map(lambda e: int(e['text_id']), r.json()['data'][:n_texts]))
     priotized_texts = get_texts_with_ids(priotized_text_ids)
-    # print('priotized texts', list(map(lambda e: e['text_id'], priotized_texts)))
 
     text_data = {'data': priotized_texts}
     return jsonify(text_data)
@@ -126,7 +125,6 @@ def get_texts_with_ids(ids):
     :param ids:
     :return:
     """
-    print('ids in get texts with ids', ids)
     conn = sqlite3.connect(DB_FILENAME)
     c = conn.cursor()
     return [

--- a/services/persistence/main.py
+++ b/services/persistence/main.py
@@ -22,12 +22,13 @@ def index():
 @app.route("/texts_and_labels", methods=['POST'])
 def texts_and_labels():
     """
-    stores the POST-body texts and labels.
+    Stores labels for the specified text ids.
 
     expects a POST-body in the format:
     {
         "data": [
             {"text_id": 17342, "label": "left"},
+            {"text_id": 873, "label": "neutral"},
             ...
         ]
     }

--- a/services/persistence/main.py
+++ b/services/persistence/main.py
@@ -2,6 +2,7 @@
 import json
 import os
 import sqlite3
+import requests
 
 from flask import Flask, jsonify, request
 
@@ -12,6 +13,9 @@ VERSION = 0.1
 
 DB_FILENAME = os.environ.get('DB_PATH')
 print('Using database', DB_FILENAME)
+
+MANIFESTO_MODEL_HTTP_PORT = os.environ.get('MANIFESTO_MODEL_HTTP_PORT')
+print('contact for manifesto model at port', MANIFESTO_MODEL_HTTP_PORT)
 
 
 @app.route("/", methods=['POST'])
@@ -40,13 +44,54 @@ def texts_and_labels():
     insert_into(DB_FILENAME, text_ids, labels, 'user')
     n_inserts = len(texts_with_labels)
 
+    # fixme: queue up examples and don't train on every user submission, or contact persistence with manifesto model with scheduler
+    training_data = {
+        'data': list(map(lambda entry: {'text': entry['statement'], 'label': entry['label']}, get_texts(1000000)))
+    }
+    url = 'http://manifesto_model:{}/train'.format(MANIFESTO_MODEL_HTTP_PORT)
+    print('sending data to manifesto model for training...')
+    r = requests.post(
+        url=url,
+        json=training_data
+    )
+    print(r.status_code)
+    print(r.json())
+
     return jsonify({'n_inserted': n_inserts}), 201
 
 
 @app.route("/texts", methods=['GET'])
 def texts():
-    n_texts = request.args.get('n')
-    text_data = {'data': get_texts(n_texts)}
+    """
+    returns json object like
+
+    {
+        'data': [
+            {'text_id': 1, 'label': 'left'},
+            ...
+        ]
+    }
+    :return:
+    """
+    # todo: fetch most uncertain texts (select, query model, send n back)
+    n_texts = int(request.args.get('n'))
+    texts = get_texts(1000000)
+
+    samples = {
+        'data': list(map(lambda entry: {'text_id': entry['text_id'], 'text': entry['statement']}, texts))
+    }
+
+    # ask model about sample uncertainty
+    url = 'http://manifesto_model:{}/estimate_uncertainty'.format(MANIFESTO_MODEL_HTTP_PORT)
+    r = requests.post(
+        url=url,
+        json=samples
+    )
+    priotized_text_ids = list(map(lambda e: int(e['text_id']), r.json()['data'][:n_texts]))
+    priotized_texts = get_texts_with_ids(priotized_text_ids)
+    print('priotized texts', list(map(lambda e: e['text_id'], priotized_texts)))
+
+    text_data = {'data': priotized_texts}
     return jsonify(text_data)
 
 
@@ -74,11 +119,36 @@ def insert_into(database_filename, text_ids, labels, annotation_source):
     conn.close()
 
 
+def get_texts_with_ids(ids):
+    """
+    :param ids:
+    :return:
+    """
+    print('ids in get texts with ids', ids)
+    conn = sqlite3.connect(DB_FILENAME)
+    c = conn.cursor()
+    return [
+        {
+            'text_id': text_id,
+            'statement': statement
+        } for text_id, statement, in c.execute(
+            """
+            SELECT
+                t.id text_id,
+                t.statement
+            FROM texts t
+            WHERE t.id IN({text_ids})""".format(text_ids=','.join('?'*len(ids))),
+            ids
+        )
+    ]
+
+
 def get_texts(n_texts):
     """
     return at most `n_texts` from the underlying storage.
     :param n_texts: how many texts to retrieve, integer.
     """
+    # fixme: 1:n relation of texts to labels, need to implement some kind of majority voting for the labels
     conn = sqlite3.connect(DB_FILENAME)
     c = conn.cursor()
     return [
@@ -88,82 +158,21 @@ def get_texts(n_texts):
             'label': label,
             'source': source
         } for text_id, statement, label, source, _, _ in c.execute(
-        """
-        SELECT
-            t.id text_id,
-            t.statement,
-            l.label,
-            l.source,
-            t.created_at,
-            l.created_at
-        FROM texts t
-        INNER JOIN labels l ON l.texts_id = t.id
-        ORDER BY RANDOM()
-        LIMIT ?""",
-        (n_texts, )
+            """
+            SELECT
+                t.id text_id,
+                t.statement,
+                l.label,
+                l.source,
+                t.created_at,
+                l.created_at
+            FROM texts t
+            INNER JOIN labels l ON l.texts_id = t.id
+            -- ORDER BY RANDOM()
+            LIMIT ?""",
+            (n_texts, )
         )
     ]
-
-
-def create_manifesto_storage(texts, labels):
-    """
-    creates required tables and inserts all of the given texts and labels.
-
-    :param texts: iterable of political texts.
-    :param labels: iterable of political text labels.
-    """
-    conn = sqlite3.connect(DB_FILENAME)
-    c = conn.cursor()
-
-    c.execute('DROP TABLE IF EXISTS texts')
-    c.execute(
-        '''CREATE TABLE texts (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                statement TEXT NOT NULL
-            )
-        '''
-    )
-    c.execute('DROP TABLE IF EXISTS labels')
-    c.execute(
-        '''CREATE TABLE labels (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                texts_id INTEGER NOT NULL,
-                label INTEGER NOT NULL,
-                source text NOT NULL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY(texts_id) REFERENCES texts(id)
-            )
-        '''
-    )
-    conn.commit()
-    conn.close()
-
-    insert_into(DB_FILENAME, texts, labels, 'manifesto')
-
-    # for statement, label, source, text_created, label_created in c.execute(
-    #         """
-    #         SELECT
-    #             t.statement,
-    #             l.label,
-    #             l.source,
-    #             t.created_at,
-    #             l.created_at
-    #         FROM texts t
-    #         INNER JOIN labels l ON l.texts_id = t.id
-    #         LIMIT 10"""
-    # ):
-    #     print(statement, label, source)
-    #
-    # print(
-    #     'inserted',
-    #     c.execute("SELECT count(1) FROM texts").fetchone(),
-    #     'texts with',
-    #     c.execute("SELECT count(1) FROM labels").fetchone(),
-    #     'labels'
-    # )
-    #
-    # conn.close()
 
 
 if __name__ == "__main__":

--- a/services/persistence/requirements.txt
+++ b/services/persistence/requirements.txt
@@ -1,2 +1,3 @@
 Flask==0.10.1
 pandas==0.19.2
+requests==2.4.2

--- a/services/user_interface/main.py
+++ b/services/user_interface/main.py
@@ -38,7 +38,7 @@ def get_samples(mock=False):
     n_texts = request.args.get('n')
     if not mock:
         r = requests.get(
-            'http://persistence:{}/texts?n={}'.format(
+            'http://persistence:{}/prioritized_texts?n={}'.format(
                 PERSISTENCE_HTTP_PORT,
                 n_texts
             )

--- a/services/user_interface/main.py
+++ b/services/user_interface/main.py
@@ -34,7 +34,7 @@ def user_labels():
 
 
 @app.route('/get_samples')
-def get_samples(mock=True):
+def get_samples(mock=False):
     n_texts = request.args.get('n')
     if not mock:
         r = requests.get(

--- a/services/user_interface/main.py
+++ b/services/user_interface/main.py
@@ -34,28 +34,15 @@ def user_labels():
 
 
 @app.route('/get_samples')
-def get_samples(mock=False):
+def get_samples():
     n_texts = request.args.get('n')
-    if not mock:
-        r = requests.get(
-            'http://persistence:{}/prioritized_texts?n={}'.format(
-                PERSISTENCE_HTTP_PORT,
-                n_texts
-            )
+    r = requests.get(
+        'http://persistence:{}/prioritized_texts?n={}'.format(
+            PERSISTENCE_HTTP_PORT,
+            n_texts
         )
-        return json.dumps(r.json())
-    else:
-        import time
-        t = str(int(time.time()))
-        return json.dumps(
-            {
-                'data': [
-                    {'text_id': 1, 'statement': 'A ' + t},
-                    {'text_id': 2, 'statement': 'B ' + t},
-                    {'text_id': 3, 'statement': 'C ' + t},
-                ]
-            }
-        )
+    )
+    return json.dumps(r.json())
 
 
 @app.route('/swipe')

--- a/services/user_interface/templates/swipe.html
+++ b/services/user_interface/templates/swipe.html
@@ -126,7 +126,7 @@
                 Instructions
             </h2>
             <div class="row">
-                <div class="col-md-4">
+                <div class="col-md-3">
                 To start labelling, please click or tap the gray area.
                 You will be shown a few political statements, for which you decide their political orientation.
                 Depending on the direction you swipe, the currently shown sample will be tagged as:
@@ -136,7 +136,7 @@
                     <li><b>neutral</b> - for swiping down</li>
                 </ul>
                 </div>
-                <div class="col-md-8"></div>
+                <div class="col-md-9"></div>
             </div>
             <div class="row">
                 <div class="col-md-12">

--- a/services/user_interface/templates/swipe.html
+++ b/services/user_interface/templates/swipe.html
@@ -53,10 +53,33 @@
           var sessionSamples = get_samples();
 
           function msg(direction) {
+            // finished labelling round
             if(swipeCount >= maxSwipes) {
               $("#political_samples_box").html("Thank you for participating in this evaluation. To start again, tap!");
               started = false;
+
+              var user_labels = sessionSamples.map(function(sample) {
+                var mapped_label = sample['label'];
+                switch(sample['label']) {
+                  case 'down':
+                    mapped_label = 'neutral';
+                }
+                return {
+                  'label': mapped_label,
+                  'text_id': sample['text_id']
+                };
+              });
+
+              data = {
+                  'data': user_labels
+              };
               console.log(sessionSamples);
+              console.log(data);
+              var request = makeHttpObject();
+              request.open("POST", "/user_labels", false);
+              request.setRequestHeader("Content-Type", "application/json");
+              request.send(JSON.stringify(data));
+
             } else {
               $("#political_samples_box").html(sessionSamples[swipeCount]['statement']);
             }
@@ -76,7 +99,7 @@
               }
             },
             swipe:function(event, direction, distance, duration, fingerCount, fingerData) {
-              if(started) {
+              if(started && (direction == 'down' || direction == 'left' || direction == 'right')) {
                 tag_current_statement(direction);
                 swipeCount++;
                 msg(direction);
@@ -93,15 +116,28 @@
     <div class="row">
         <div class="col-md-12">
             <h1 class="text-center">
-                Active Manifesto
+                Active Manifesto - Political Statement Tagger
             </h1>
         </div>
     </div>
     <div class="row">
         <div class="col-md-12">
             <h2>
-                Political Samples
+                Instructions
             </h2>
+            <div class="row">
+                <div class="col-md-4">
+                To start labelling, please click or tap the gray area.
+                You will be shown a few political statements, for which you decide their political orientation.
+                Depending on the direction you swipe, the currently shown sample will be tagged as:
+                <ul>
+                    <li><b>left</b> - for swiping left</li>
+                    <li><b>right</b> - for swiping right</li>
+                    <li><b>neutral</b> - for swiping down</li>
+                </ul>
+                </div>
+                <div class="col-md-8"></div>
+            </div>
             <div class="row">
                 <div class="col-md-12">
                     <div id="swipe" style="height: 250px; width: 350px; background-color: rgba(0,0,0,0.1);">


### PR DESCRIPTION
Hi Felix,

habe jetzt die komplette Pipeline des Modells fertig. Ist an einigen Stellen noch nicht ganz rund, laeuft aber:

* manifesto model wird jede stunde neu trainiert (indem es die datenbank nach aktuellen samples fragt + model selection).
* persistence gibt dem manifesto modell majority voted annotierte trainings daten auf anfrage.
* im UI kann man jetzt samples prioritized samples requested (grober flow: UI -> persistence(get texts) -> model(estimate uncertainty) -> persistence(only return n most uncertain texts) -> UI).

der letzte punkt ist nicht so schoen, da jedes mal neu geranked wird, ist aber auch das genauste und dauert auch nicht wirklich lange.
allerdings werden durch das geschedulte training zwischen jedem training immer die gleich texte fuers labeln zurueckgeben, das koennte auch sinn machen (dann sammelt man eben, 60 minuten lang labels fuer diese instanzen). koennen auch einfach das trainingsintervall kuerzer machen.